### PR TITLE
Add AnimatedGif Screensaver for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ This is a list of tools, scripts, libraries, examples & other resources related 
 - [VineGifR](https://github.com/esten/VineGifR) - Mac app to turn Vine videos into GIFs
 - [GifPro](https://github.com/unixpickle/GifPro) - GIF encoder for Mac
 - [Gif Maker](https://movielala.com/gif-maker/) - High quailty GIF maker with filters for Mac
+- [AnimatedGif](https://github.com/Waitsnake/AnimatedGif) - Mac Screensaver for playing GIFs
 
 ### Hosting
 


### PR DESCRIPTION
Add AnimatedGif a screensaver for Mac OSX / macOS that plays animated
GIFs. It has a background mode to see the GIFs as animated Wallpaper
on your Mac desktop. It uses OpenGL to run at low CPU load.