### PR TITLE
Add BulkPicTools to Online Tools — browser-based GIF maker/compressor…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ A list of tools, scripts, libraries, examples & other resources related to the G
 - [EzGif](https://ezgif.com/) - Online GIF maker and image editor.
 - [Giflr](https://giflr.com/) - A web app for making or remixing animated GIFs.
 - [GIF Frame Extractor](https://giftoframes.org/) - Convert animated GIFs into individual frames online.
+- [BulkPicTools](https://bulkpictools.com/tools/gif/gif-maker) - Free browser-based GIF toolkit: create, compress, resize GIFs and convert videos to GIF — all processed locally, no upload.
 
 ## Community
 


### PR DESCRIPTION
…, no upload

## What

Adding BulkPicTools to the Online Tools section.

It covers several GIF use cases in one place:
- GIF Maker (images → GIF)
- Video to GIF converter  
- GIF Compressor
- GIF Resizer

## Why it fits

Current online tools in the list (EzGIF, Giflr) require file uploads to a server.  BulkPicTools processes everything client-side via WebAssembly — files never leave  the device. Useful addition for users who care about privacy or work with  sensitive content.

Free, no account required, works offline.

## Checklist
- [x] Follows existing list format
- [x] Tool is free, no signup required
- [x] Not a duplicate of existing entries
- [x] Inserted in alphabetical order