### PR TITLE
Add VideoKit to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ A list of tools, scripts, libraries, examples & other resources related to the G
 - [EzGif](https://ezgif.com/) - Online GIF maker and image editor.
 - [Giflr](https://giflr.com/) - A web app for making or remixing animated GIFs.
 - [GIF Frame Extractor](https://giftoframes.org/) - Convert animated GIFs into individual frames online.
+- [VideoKit](https://www.videokit.cc/en) - Convert video to GIF, GIF to video and images to GIF in the browser, with control over width, frame rate and quality.
 
 ## Community
 


### PR DESCRIPTION
Adding VideoKit to **Online Tools**, alongside EzGif and the other online GIF tools.

Disclosure, per contributing.md: I maintain this site.

It covers the three GIF directions — video to GIF, GIF back to video, and images to GIF — with width, frame rate and quality controls. The conversion happens in the browser through the WebCodecs API rather than on a server, so nothing gets uploaded. Free, no account needed.

Followed the manual of style in contributing.md (no tag, since the entries in that section don't use one). Happy to trim the description or move it if you'd rather it sat elsewhere.